### PR TITLE
Change deployed version to 1.0

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -17,7 +17,7 @@ spec:
         app: web
     spec:
       containers:
-      - image: nigelpoulton/k8s101-sksh:2.0
+      - image: nigelpoulton/k8s101-sksh:1.0
         name: web-ctr
         ports:
         - containerPort: 8080


### PR DESCRIPTION
To match the skillshare video, initially the deploy.yml should bring up `nigelpoulton/k8s101-sksh:1.0` instead of 2.0